### PR TITLE
fix:修复onTouchEvent方法里面重复调用performClick方法的bug。

### DIFF
--- a/tabradiobutton/src/main/java/com/zaaach/tabradiobutton/TabRadioButton.java
+++ b/tabradiobutton/src/main/java/com/zaaach/tabradiobutton/TabRadioButton.java
@@ -90,7 +90,7 @@ public class TabRadioButton extends android.support.v7.widget.AppCompatRadioButt
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        this.performClick();
+        
         switch (event.getAction()){
             case MotionEvent.ACTION_DOWN:
                 //手指按下时开始动画


### PR DESCRIPTION
以下是部分日志：
E/PhoneWindow: onInterceptTouchEvent action ::: 2
E/PhoneWindow: dispatchTouchEvent--------------
E/PhoneWindow: onInterceptTouchEvent action ::: 2
E/PhoneWindow: dispatchTouchEvent--------------
E/PhoneWindow: onInterceptTouchEvent action ::: 2
E/PhoneWindow: dispatchTouchEvent--------------
E/PhoneWindow: onInterceptTouchEvent action ::: 2
E/PhoneWindow: dispatchTouchEvent--------------
E/PhoneWindow: onInterceptTouchEvent action ::: 1